### PR TITLE
Moves Prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ava": "2.4.0",
     "coveralls": "^3.0.2",
     "nyc": "^13.1.0",
+    "prettier": "^1.18.2",
     "ts-node": "^9.0.0",
     "tslint": "^5.11.0",
     "tslint-eslint-rules": "^5.4.0",
@@ -42,7 +43,6 @@
     "fs-extra": "^5.0.0",
     "json-diff": "^0.5.2",
     "lodash": "^4.17.10",
-    "prettier": "^1.18.2",
     "yargs": "^11.0.0"
   },
   "ava": {


### PR DESCRIPTION
This project currently has an older version of `prettier` included in its `dependencies`. 

This is causing a problem by conflicting with the newer version of prettier in a project I'm working on.

In general, I don't believe build tools need to be in `dependencies` and can be specified in `devDependencies`.

This moves `prettier` from `dependencies` to `devDependencies`, and leaves it at the same version.