### PR TITLE
fix: use an actually-existing rate limit header

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -84,7 +84,7 @@ export default class SimpleCMAClient {
       }
 
       if (resp.status == 429) {
-        const reset = resp.headers.get('X-Contentful-RateLimit-Reset')
+        const reset = resp.headers.get('x-contentful-ratelimit-second-limit');
         if (!reset) { throw new Error(`Rate-limited with no X-Contentful-RateLimit-Reset header!`) }
 
         await wait(parseFloat(reset) * 1000)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved rate limit handling by correcting the HTTP header source used to calculate retry timing. When API rate limits are encountered, the system now reads from the appropriate header to determine when retries should occur, resulting in more accurate and reliable automatic retry behavior during high-usage periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->